### PR TITLE
Fix typo and add mockito exception message

### DIFF
--- a/src/graderPublic/java/h12/h2/TutorTests_WriteJSONTest.java
+++ b/src/graderPublic/java/h12/h2/TutorTests_WriteJSONTest.java
@@ -75,7 +75,7 @@ public class TutorTests_WriteJSONTest {
             } catch (IOException e) {
                 throw new RuntimeException(e);
             } catch (MockitoAssertionError e) {
-                fail(context, TR -> "Expected the method write of the object " + jsonElement.toString() +" to be called exactly " + count + "times but it wasn't");
+                fail(context, TR -> "Expected the method write of the object " + jsonElement.toString() + " to be called exactly " + count + " times but it wasn't" + e.getMessage());
             }
         };
     }

--- a/src/graderPublic/java/h12/h2/TutorTests_WriteJSONTest.java
+++ b/src/graderPublic/java/h12/h2/TutorTests_WriteJSONTest.java
@@ -75,7 +75,8 @@ public class TutorTests_WriteJSONTest {
             } catch (IOException e) {
                 throw new RuntimeException(e);
             } catch (MockitoAssertionError e) {
-                fail(context, TR -> "Expected the method write of the object " + jsonElement.toString() + " to be called exactly " + count + " times but it wasn't" + e.getMessage());
+                fail(context, TR -> "Expected the method write of the object " + jsonElement.toString() +
+                    " to be called exactly " + count + " times but it wasn't.\n Original message: " + e.getMessage());
             }
         };
     }

--- a/src/graderPublic/java/h12/h3/TutorTests_H3_1_H3_2_JSONElementNodeParserTest.java
+++ b/src/graderPublic/java/h12/h3/TutorTests_H3_1_H3_2_JSONElementNodeParserTest.java
@@ -299,8 +299,9 @@ public class TutorTests_H3_1_H3_2_JSONElementNodeParserTest extends TutorTests_J
             try {
                 verifier.accept(elementParser);
             } catch (MockitoAssertionError e) {
-                fail(context, TR -> "Expected the method parse() of class " + expected.getClass().getSimpleName() +
-                    "Parser to be called once but it did not get called or got called multiple times");
+                fail(context, TR -> "Expected the method parse() of class " + expected.getClass().getSimpleName()
+                    + "Parser to be called once but it did not get called or got called multiple times"
+                    + "\n Original message: " + e.getMessage());
             }
         }
     }

--- a/src/graderPublic/java/h12/h3/TutorTests_JSONParseTest.java
+++ b/src/graderPublic/java/h12/h3/TutorTests_JSONParseTest.java
@@ -142,7 +142,8 @@ public class TutorTests_JSONParseTest {
             } catch (IOException e) {
                 throw new RuntimeException(e);
             } catch (MockitoAssertionError e) {
-                fail(context, TR -> "Expected the method parse of class JSONElementNodeParser to be called exactly " + count + "times but it wasn't");
+                fail(context, TR -> "Expected the method parse of class JSONElementNodeParser to be called exactly " + count + "times but it wasn't"
+                 + "\n Original message: " + e.getMessage());
             }
         };
     }
@@ -157,7 +158,8 @@ public class TutorTests_JSONParseTest {
             } catch (IOException e) {
                 throw new RuntimeException(e);
             } catch (MockitoAssertionError e) {
-                fail(context, TR -> "Expected the method parse of class " + parser + " to be called exactly " + count + "times but it wasn't");
+                fail(context, TR -> "Expected the method parse of class " + parser + " to be called exactly " + count + "times but it wasn't"
+                + "\n Original message: " + e.getMessage());
             }
         };
     }

--- a/src/graderPublic/java/h12/h4/TutorTests_H4_1_JSONParserTest.java
+++ b/src/graderPublic/java/h12/h4/TutorTests_H4_1_JSONParserTest.java
@@ -40,13 +40,15 @@ public class TutorTests_H4_1_JSONParserTest {
         try {
             verify(elementNodeParser, times(1)).parse();
         } catch (MockitoAssertionError e) {
-            fail(context, TR -> "Expected method parse of class elementNodeParser to be called excatly once but it wasn't");
+            fail(context, TR -> "Expected method parse of class elementNodeParser to be called exactly once and before checkEndOfFile but it wasn't"
+            + "\n Original message: " + e.getMessage());
         }
 
         try {
             verify(elementNodeParser, times(1)).checkEndOfFile();
         } catch (MockitoAssertionError e) {
-            fail(context, TR -> "Expected method checkEndOfFile of class elementNodeParser to be called excatly once but it wasn't");
+            fail(context, TR -> "Expected method checkEndOfFile of class elementNodeParser to be called exactly once and after parse but it wasn't"
+            + "\n Original message: " + e.getMessage());
         }
 
         inOrder.verify(elementNodeParser, times(1)).parse();


### PR DESCRIPTION
Adding the message of the thrown exception would greatly improve the amount of information provided upon failing the test, such as how many times the method in question was called and where.